### PR TITLE
Add Rails' master.key to dorks list

### DIFF
--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -73,6 +73,7 @@ filename:CCCam.cfg
 msg nickserv identify filename:config
 filename:settings.py SECRET_KEY
 filename:secrets.yml password
+filename:master.key
 filename:deployment-config.json
 filename:.ftpconfig
 filename:.remote-sync.json

--- a/github-dorks.txt
+++ b/github-dorks.txt
@@ -73,7 +73,7 @@ filename:CCCam.cfg
 msg nickserv identify filename:config
 filename:settings.py SECRET_KEY
 filename:secrets.yml password
-filename:master.key
+filename:master.key path:config
 filename:deployment-config.json
 filename:.ftpconfig
 filename:.remote-sync.json


### PR DESCRIPTION
Rails 5.2+ has a `config/credentials.yml.enc` file and a `config/master.key` to decrypt it.

See this article for more info: https://www.engineyard.com/blog/rails-encrypted-credentials-on-rails-5.2

- Search URL: https://github.com/search?p=3&q=filename%3Amaster.key+path%3Aconfig&type=Code
- Number of search results at time of PR: 8000 (33000 if you get rid of the path specifier, but I imagine that has false positives)
- Impact of data disclosed (see table below): Moderate up to Critical, depending on whether the user has actually stored anything like AWS keys in the credentials file.
- Description of data disclosed: Secret key base, secret AWS credentials, etc.

This is what the decrypted `credentials.yml` file looks like (from a Rails app I created just now for testing):

```yml
# aws:
#   access_key_id: 123
#   secret_access_key: 345

# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
secret_key_base: 111e265cc90f2ae073610628f5f0bb0ed9056beeeb502a64d4c3b05493810e2c4671eaa03e74ef786e74f2c23958f16c690812efba27e8bab8b5e1872611d6f5
```

There's not really a point to searching for decrypted credentials.yml files on GitHub because when you edit them with `rails credentials:edit` they open in a temporary file outside the Rails app's directory, so you'd have to try pretty hard to commit them.

The `master.key` file is ignored by default when creating an app with `rails new`, but Rails templates sometimes mess with the `.gitignore`, or users delete the default .gitignore for whatever reason.